### PR TITLE
Restore missing doc entries

### DIFF
--- a/.docs/user-guide/storage-providers/microsoft.md
+++ b/.docs/user-guide/storage-providers/microsoft.md
@@ -86,7 +86,7 @@ the driver name.
 
 ### Troubleshooting
 * For help creating App Registrations, the steps in
-  [this guide](https://www.terraform.io/docs/providers/azurerm/index.html#creating-credentials)
+  [this guide](https://www.terraform.io/docs/providers/azurerm/authenticating_via_service_principal.html#creating-a-service-principal)
   cover creating a new Registration using the Azure portal and CLI.
 * After creating your app registration, you must go into the
   `Required Permissions` tab and grant access to "Windows Azure Service

--- a/.docs/user-guide/storage-providers/openstack.md
+++ b/.docs/user-guide/storage-providers/openstack.md
@@ -26,6 +26,9 @@ cinder:
   domainName:           corp
   regionName:           USNW
   availabilityZoneName: Gold
+  attachTimeout:        1m
+  createTimeout:        10m
+  deleteTimeout:        10m
 ```
 
 #### Configuration Notes


### PR DESCRIPTION
When the storage-provider section of the user guide was split into
subsections (efb48e4343d9c36c3993adac37c5d6768439d73d), that commit
missed several doc updates that had been made.

This patch restores them.

If you look at https://github.com/thecodeteam/rexray/commits/master/.docs/user-guide/storage-providers.md, the commits that were merged on October 5, 6, and 11 all failed to ported over into the doc structure.