### PR TITLE
Add support to build the RBD plugin on AArch64

### DIFF
--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 RUN apk update
 RUN apk add xfsprogs e2fsprogs ca-certificates
 
-RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN mkdir -p /lib64 && ln -s /lib/libc.musl-$(uname -m).so.1 /lib64/ld-linux-$(uname -m).so.2
 RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes
 ADD rexray /usr/bin/rexray
 ADD rexray.yml /etc/rexray/rexray.yml

--- a/.docker/plugins/rbd/.Dockerfile
+++ b/.docker/plugins/rbd/.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.4.1708
+FROM centos:latest
 
 ENV CEPH_VERSION luminous
 


### PR DESCRIPTION
Update the Dockerfile in favor of the multi-arch images
to support build the RBD plugins on AArch64 platforms:

`$DRIVER=rbd make build-docker-plugin`
Have been tested on both amd64 and arm64.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>