### PR TITLE
Update aws.md

### DIFF
--- a/.docs/user-guide/storage-providers/aws.md
+++ b/.docs/user-guide/storage-providers/aws.md
@@ -20,6 +20,11 @@ Storage volumes for EC2 instances.
 !!! note
     The EBS driver does not yet support snapshots or tags, as previously
     supported in Rex-Ray v0.3.3.
+    
+!!! note
+    Due to issues with device naming, it is currently not possible to run the rexray/ebs 
+    plugin on 5th generation (C5 and M5) instances in AWS. See [here](https://github.com/rexray/rexray/issues/1104)
+    for more information.
 
 The EBS driver is made possible by the
 [official Amazon Go AWS SDK](https://github.com/aws/aws-sdk-go.git).


### PR DESCRIPTION
It was not possible to run rexray on 5th generation AWS instances, which our relevant infrastructure uses. An early warning in the documentation would have been super handy!