### PR TITLE
Close anchor tag - digitalocean.md

### DIFF
--- a/.docs/user-guide/schedulers/docker/plug-ins/digitalocean.md
+++ b/.docs/user-guide/schedulers/docker/plug-ins/digitalocean.md
@@ -5,9 +5,9 @@ Block Storage
 ---
 
 <a name="digitalocean-block-storage"></a>
-<a name="dobs"></a
+<a name="dobs"></a>
 
-## DO Block Storage>
+## DO Block Storage
 The DOBS plug-in can be installed with the following command:
 
 ```bash


### PR DESCRIPTION
Anchor tag not closed properly. This closes it so all text on the page isn't underlined when the mouse is hovering over the text.