### PR TITLE
Fix links to {code} Community and #project-rexray Slack

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -175,5 +175,7 @@ Marathon          | Docker, Mesos Containerizer
 ### GitHub and Slack
 If a little extra help is needed, please don't hesitate to use [GitHub
 issues](https://github.com/rexray/rexray/issues) or join the active
-conversation on the [{code} by Dell EMC Community Slack
-Team](http://community.codedellemc.com/) in the #project-rexray channel
+conversation on the [{code} Community Slack
+Team](https://thecodeteam.com/community/) in the
+[#project-rexray](https://codecommunity.slack.com/channels/project-rexray)
+channel.


### PR DESCRIPTION
Add a direct link to #project-rexray in slack.

Fixes #1222 