### PR TITLE
Support NVME EBS Volumes on M5 / C5

### DIFF
--- a/libstorage/drivers/storage/ebs/utils/utils.go
+++ b/libstorage/drivers/storage/ebs/utils/utils.go
@@ -44,6 +44,7 @@ type instanceIdentityDoc struct {
 	InstanceID       string `json:"instanceId,omitempty"`
 	Region           string `json:"region,omitempty"`
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
+	InstanceType     string `json:"instanceType,omitempty"`
 }
 
 // InstanceID returns the instance ID for the local host.
@@ -74,6 +75,7 @@ func InstanceID(
 		Fields: map[string]string{
 			ebs.InstanceIDFieldRegion:           iid.Region,
 			ebs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,
+			"instanceType":                      iid.InstanceType,
 		},
 	}, nil
 }

--- a/libstorage/drivers/storage/ebs/utils/utils_unix.go
+++ b/libstorage/drivers/storage/ebs/utils/utils_unix.go
@@ -4,8 +4,10 @@ package utils
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/rexray/rexray/libstorage/api/types"
+	log "github.com/sirupsen/logrus"
 )
 
 // DeviceRange holds slices for device namespace iteration
@@ -49,10 +51,27 @@ var (
 		},
 		DeviceRE: regexp.MustCompile(`^xvd[f-p]$`),
 	}
+	nvmeDeviceRange = &DeviceRange{
+		ParentLetters: []string{"0"},
+		ChildLetters: []string{
+			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+			"14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26"},
+		NextDeviceInfo: &types.NextDeviceInfo{
+			Prefix:  "nvme",
+			Pattern: "[0-26]n.*",
+			Ignore:  false,
+		},
+		DeviceRE: regexp.MustCompile(`^nvme[0-26]n.*`),
+	}
 )
 
 // GetDeviceRange returns a specified DeviceRange object
-func GetDeviceRange(useLargeDeviceRange bool) *DeviceRange {
+func GetDeviceRange(useLargeDeviceRange bool, instanceType string) *DeviceRange {
+	log.Debug("InstanceType: ", instanceType)
+	if strings.HasPrefix(instanceType, "c5") || strings.HasPrefix(instanceType, "m5") {
+		log.Debug("nvme device")
+		return nvmeDeviceRange
+	}
 	if useLargeDeviceRange {
 		return largeDeviceRange
 	}


### PR DESCRIPTION
With custom udev rules[1] and nvme-cli, this change set provides support for NVME EBS volumes on C5/M5 families of EC2 instances.

#### Example udev rule
```sh
# /etc/udev/rules.d/999-aws-ebs-nvme.rules
# ebs nvme devices
KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/usr/local/bin/ebs-nvme-mapping /dev/%k", SYMLINK+="%c"
```

#### Helper script for udev rules
```sh
#!/bin/bash
#/usr/local/bin/ebs-nvme-mapping
vol=$(/usr/sbin/nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
vol=${vol#/dev/}
if [[ -n "$vol" ]]; then
  echo ${vol/xvd/sd} ${vol/sd/xvd}
fi
```

#### Based on:
1) https://gist.github.com/jalaziz/bcfe2f71e3f7e8fe42a9c294c1e9279f