### PR TITLE
feat: add generic nvme support

### DIFF
--- a/.docker/plugins/Dockerfile
+++ b/.docker/plugins/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 RUN apk update
-RUN apk add xfsprogs e2fsprogs ca-certificates
+RUN apk add xfsprogs e2fsprogs ca-certificates nvme-cli
 
 RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 RUN mkdir -p /etc/rexray /run/docker/plugins /var/lib/rexray/volumes


### PR DESCRIPTION
## What?

This is my local work, trying to solve same issue as #1233 

This PR makes NVMe transparent to rexray, as it translates between the NVMe logical device and the virtual device that is the udev symlink with the device name that rexray request EC2 to mount the EBS volume as

## Tested on 

- [x] c4
- [x] c5
- [x] c5d
- [x] m4
- [x] m5
- [x] m5d
- [x] r4
- [x] r5
- [x] r5d
- [x] i3.2xlarge

## Requirements

Require a `udev` rule to alias the NVMe device to the path that rexray expects as mount point.

A similar udev rule is build into the Amazon Linux AMI already, and trivial to add to other linux distributions (see below)

An alternative is to manage the symlinks from the rexray driver (its just a symlink), but seem like feature creep to me, considering the low effort required to make the `udev` setup work

### Example udev rule

```
# /etc/udev/rules.d/999-aws-ebs-nvme.rules
# ebs nvme devices
KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/usr/local/bin/ebs-nvme-mapping /dev/%k", SYMLINK+="%c"
```

### Helper script for udev rules

```sh
#!/bin/bash
#/usr/local/bin/ebs-nvme-mapping
vol=$(/usr/sbin/nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
vol=${vol#/dev/}
if [[ -n "$vol" ]]; then
  echo ${vol/xvd/sd} ${vol/sd/xvd}
fi
```

Signed-off-by: Christian Winther <jippignu@gmail.com>