### PR TITLE
add `S3FS_CONVERTUNDERSCORES` env into s3 conf.json

### DIFF
--- a/.docker/plugins/s3fs/config.json
+++ b/.docker/plugins/s3fs/config.json
@@ -130,7 +130,15 @@
             "value"
           ],
           "Value": "false"
-        }
+        },
+        {
+          "Description": "",
+          "Name": "S3FS_CONVERTUNDERSCORES",
+          "Settable": [
+            "value"
+          ],
+          "Value": "false"
+        }            
       ],
       "Interface": {
         "Socket": "rexray.sock",


### PR DESCRIPTION
the purpose is to take choice to convert underscore between my stack name and the service. because as you know aws S3 don't support `_` in buckets names.
please i wish that you will making some stuff for that.
i'm waiting for your feedback and thanks for your attention.