### PR TITLE
WiP - Look at availability zones when searching for EFS mount targets

### DIFF
--- a/libstorage/drivers/storage/efs/efs.go
+++ b/libstorage/drivers/storage/efs/efs.go
@@ -37,6 +37,10 @@ const (
 	// group value from the InstanceID Field map.
 	InstanceIDFieldSecurityGroups = "securityGroups"
 
+	// InstanceIDFieldSubnetID is the key of the subnet where the instance lives from the
+	// InstanceID Field map
+	InstanceIDFieldSubnetID = "subnet"
+
 	// AccessKey is a key constant.
 	AccessKey = "accessKey"
 
@@ -54,6 +58,12 @@ const (
 
 	// EndpointFormat is a key constant.
 	EndpointFormat = "endpointFormat"
+
+	// Endpoint is a key constant.
+	EC2Endpoint = "ec2endpoint"
+
+	// EndpointFormat is a key constant.
+	EC2EndpointFormat = "ec2endpointFormat"
 
 	// MaxRetries is a key constant.
 	MaxRetries = "maxRetries"
@@ -91,6 +101,12 @@ const (
 	// ConfigEFSEndpointFormat is a config key.
 	ConfigEFSEndpointFormat = ConfigEFS + "." + EndpointFormat
 
+	// ConfigEC2Endpoint is a config key.
+	ConfigEC2Endpoint = ConfigEFS + "." + EC2Endpoint
+
+	// ConfigEC2EndpointFormat is a config key.
+	ConfigEC2EndpointFormat = ConfigEFS + "." + EC2EndpointFormat
+
 	// ConfigEFSMaxRetries is a config key.
 	ConfigEFSMaxRetries = ConfigEFS + "." + MaxRetries
 
@@ -123,6 +139,9 @@ func init() {
 	r.Key(gofig.String, "", "", "AWS EFS endpoint", ConfigEFSEndpoint)
 	r.Key(gofig.String, "", `elasticfilesystem.%s.amazonaws.com`,
 		"AWS EFS endpoint format", ConfigEFSEndpointFormat)
+	r.Key(gofig.String, "", "", "AWS EC2 endpoint", ConfigEC2Endpoint)
+	r.Key(gofig.String, "", `ec2.%s.amazonaws.com`,
+		"AWS EC2 endpoint format", ConfigEC2EndpointFormat)
 	r.Key(gofig.String, "", "", "Tag prefix for EFS naming", ConfigEFSTag)
 	r.Key(gofig.Bool, "", false,
 		"A flag that disables the session cache",

--- a/libstorage/drivers/storage/efs/utils/utils.go
+++ b/libstorage/drivers/storage/efs/utils/utils.go
@@ -89,6 +89,7 @@ func InstanceID(ctx types.Context) (*types.InstanceID, error) {
 	iidFields := map[string]string{
 		efs.InstanceIDFieldRegion:           iid.Region,
 		efs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,
+		efs.InstanceIDFieldSubnetID:         subnetID,
 	}
 
 	if len(secGroups) > 0 {
@@ -97,7 +98,7 @@ func InstanceID(ctx types.Context) (*types.InstanceID, error) {
 	}
 
 	return &types.InstanceID{
-		ID:     subnetID,
+		ID:     iid.InstanceID,
 		Driver: efs.Name,
 		Fields: iidFields,
 	}, nil


### PR DESCRIPTION
This pull-request contains changes to fix the problem described in #1228. 
Before this commit the EFS driver would select a mount target based on the subnet it is in. All mount targets in subnets not equal to the subnet of the host would be ignored. This is incorrect behaviour as subnets do not restrict access to a mount target. Now the mount target selection is implemented by looking at the availability zone of the mount target and host as these must be equal for the host to reach the mount target.

*This pull-request is not ready to be merged. The following things must be done first:*

- [ ] Testing. I tested these changes a bit but not enough for release. Please test in some different situations.
- [ ] EC2 permissions documentation and testing: It is not possible to request the availability zone of a mount target directly through the aws efs api. A workaround is to request the availability zone of the subnet of the mount target as a mount target always lives in 1 availability zone and has 1 subnet. To do this, rexray needs to access the aws ec2 api. I implemented this but have not tested if any new authorization parameters are required. This should be investigated and documented.
- [ ] Code Review. This was my first time working on such a big go project so please revew the code before taking this into production.

Because of reasons, i won't be able to finish the work that i started here :disappointed: . I hope this helps someone in the right direction of a permanent fix :smile: 
