### PR TITLE
Add S3FS plugin troubleshooting section

### DIFF
--- a/.docs/user-guide/storage-providers/aws.md
+++ b/.docs/user-guide/storage-providers/aws.md
@@ -393,6 +393,11 @@ To activate the AWS S3FS driver please follow the instructions for
 [activating storage drivers](./../servers/libstorage.md#storage-drivers),
 using `s3fs` as the driver name.
 
+### Troubleshooting
+- Make sure that AWS credentials (user or role) has following AWS permissions on
+  `libStorage` server instance that will be making calls to AWS API:
+    - `s3:*`,
+
 <a name="aws-s3fs-examples"></a>
 
 ### Examples

--- a/.docs/user-guide/storage-providers/aws.md
+++ b/.docs/user-guide/storage-providers/aws.md
@@ -396,7 +396,7 @@ using `s3fs` as the driver name.
 ### Troubleshooting
 - Make sure that AWS credentials (user or role) has following AWS permissions on
   `libStorage` server instance that will be making calls to AWS API:
-    - `s3:*`,
+    - `s3:*`
 
 <a name="aws-s3fs-examples"></a>
 


### PR DESCRIPTION
The S3FS plugin doesn't have the Troubleshooting section that states which role permissions are necessary.

I need help finishing this PR, since I don't know which permissions s3fs needs. Obviously `s3:*` is not the correct answer.