### PR TITLE
cinder fix issue mapping device name on Xen hypervisor

### DIFF
--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -197,6 +197,14 @@
         },
         {
           "Description": "",
+          "Name": "CINDER_MAPPINGTYPE",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "CINDER_DEVICEPATTERN",
           "Settable": [
             "value"

--- a/.docker/plugins/cinder/config.json
+++ b/.docker/plugins/cinder/config.json
@@ -196,6 +196,22 @@
           "Value": ""
         },
         {
+          "Description": "",
+          "Name": "CINDER_DEVICEPATTERN",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "CINDER_HOSTPATTERN",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
           "Description": "The sock file used by the CO to communicate with CSI.",
           "Name": "CSI_ENDPOINT",
           "Settable": [

--- a/libstorage/drivers/storage/cinder/cinder.go
+++ b/libstorage/drivers/storage/cinder/cinder.go
@@ -64,8 +64,11 @@ const (
 	// ConfigInsecure is the config key to disable TLS verification of the server identity
 	ConfigInsecure = Name + ".insecure"
 
-	// ConfigDevicePattern is the config key to specify de the device name pattern
+	// ConfigDevicePattern is the config key to specify the device name pattern returned by Cinder
 	ConfigDevicePattern = Name + ".devicePattern" 
+	
+	// ConfigHostPattern is the config key to specify de the device name pattern used by the host
+	ConfigHostPattern = Name + ".hostPattern" 
 )
 
 func init() {
@@ -89,5 +92,6 @@ func init() {
 	r.Key(gofig.String, "", "", "", ConfigCACert)
 	r.Key(gofig.Bool, "", false, "", ConfigInsecure)
 	r.Key(gofig.String, "", "", "", ConfigDevicePattern)
+	r.Key(gofig.String, "", "", "", ConfigHostPattern)
 	gofigCore.Register(r)
 }

--- a/libstorage/drivers/storage/cinder/cinder.go
+++ b/libstorage/drivers/storage/cinder/cinder.go
@@ -3,6 +3,9 @@ package cinder
 import (
 	gofigCore "github.com/akutz/gofig"
 	gofig "github.com/akutz/gofig/types"
+	
+	"github.com/rexray/rexray/libstorage/api/types"
+
 )
 
 const (
@@ -69,6 +72,9 @@ const (
 	
 	// ConfigHostPattern is the config key to specify de the device name pattern used by the host
 	ConfigHostPattern = Name + ".hostPattern" 
+
+	// ConfigMappingType is the device mapping type: ebs or virtio 
+	ConfigMappingType = Name + ".mappingType"
 )
 
 func init() {
@@ -91,7 +97,17 @@ func init() {
 	r.Key(gofig.String, "", "10m", "", ConfigSnapshotTimeout)
 	r.Key(gofig.String, "", "", "", ConfigCACert)
 	r.Key(gofig.Bool, "", false, "", ConfigInsecure)
-	r.Key(gofig.String, "", "", "", ConfigDevicePattern)
-	r.Key(gofig.String, "", "", "", ConfigHostPattern)
+	r.Key(gofig.String, "", "", "", ConfigMappingType)
+	r.Key(gofig.String, "", "/dev/sd", "", ConfigDevicePattern)
+	r.Key(gofig.String, "", "/dev/xvd", "", ConfigHostPattern)
 	gofigCore.Register(r)
 }
+
+
+// Driver extend driver type so it possible to resolve the correct device name attached to an host
+type Driver interface{
+	ResolveDeviceName(ctx types.Context, device string, volumeID string) string
+}
+
+
+

--- a/libstorage/drivers/storage/cinder/cinder.go
+++ b/libstorage/drivers/storage/cinder/cinder.go
@@ -111,3 +111,4 @@ type Driver interface{
 
 
 
+

--- a/libstorage/drivers/storage/cinder/cinder.go
+++ b/libstorage/drivers/storage/cinder/cinder.go
@@ -61,8 +61,11 @@ const (
 	// ConfigCACert is the config key for custom CA certificate (usually for self signed use case)
 	ConfigCACert = Name + ".CACert"
 
-	// ConfigInsecure is the config ky to disable TLS verification of the server identity
+	// ConfigInsecure is the config key to disable TLS verification of the server identity
 	ConfigInsecure = Name + ".insecure"
+
+	// ConfigDevicePattern is the config key to specify de the device name pattern
+	ConfigDevicePattern = Name + ".devicePattern" 
 )
 
 func init() {
@@ -85,5 +88,6 @@ func init() {
 	r.Key(gofig.String, "", "10m", "", ConfigSnapshotTimeout)
 	r.Key(gofig.String, "", "", "", ConfigCACert)
 	r.Key(gofig.Bool, "", false, "", ConfigInsecure)
+	r.Key(gofig.String, "", "", "", ConfigDevicePattern)
 	gofigCore.Register(r)
 }

--- a/libstorage/drivers/storage/cinder/cinder.go
+++ b/libstorage/drivers/storage/cinder/cinder.go
@@ -3,9 +3,6 @@ package cinder
 import (
 	gofigCore "github.com/akutz/gofig"
 	gofig "github.com/akutz/gofig/types"
-	
-	"github.com/rexray/rexray/libstorage/api/types"
-
 )
 
 const (
@@ -104,10 +101,6 @@ func init() {
 }
 
 
-// Driver extend driver type so it possible to resolve the correct device name attached to an host
-type Driver interface{
-	ResolveDeviceName(ctx types.Context, device string, volumeID string) string
-}
 
 
 

--- a/libstorage/drivers/storage/cinder/executor/cinder_executor.go
+++ b/libstorage/drivers/storage/cinder/executor/cinder_executor.go
@@ -214,7 +214,9 @@ func (d *driver) LocalDevices(
 		fields := strings.Fields(line)
 		if len(fields) >= 4 {
 			devicePath := "/dev/" + fields[3]
-			devicesMap[devicePath] = ""
+			devicesMap[devicePath] = strings.Replace(devicePath,
+				d.config.GetString(cinder.ConfigHostPattern),
+				d.config.GetString(cinder.ConfigDevicePattern),1)
 		}
 	}
 

--- a/libstorage/drivers/storage/cinder/executor/cinder_executor.go
+++ b/libstorage/drivers/storage/cinder/executor/cinder_executor.go
@@ -25,7 +25,6 @@ import (
 
 
 type driver struct {
-	cinder.Driver
 	config   gofig.Config
 	osDriver types.OSDriver
 	deviceRange *DeviceRange
@@ -304,21 +303,3 @@ func (d *driver) LocalDevices(
 	}, nil
 }
 
-func (d *driver) ResolveDeviceName(ctx types.Context, device string, volumeID string) string{
-	if strings.ToLower(d.config.GetString(cinder.ConfigMappingType))=="ebs" {
-	return strings.Replace(
-		string(device),
-		d.config.GetString(cinder.ConfigDevicePattern),
-		d.config.GetString(cinder.ConfigHostPattern),
-		1)
-	} else if strings.ToLower(d.config.GetString(cinder.ConfigMappingType))=="virtio"{
-		attachedDeviceLink := fmt.Sprintf("/dev/disk/by-id/virtio-%s", volumeID[:20])
-	    attachedDeviceName, err := filepath.EvalSymlinks(attachedDeviceLink)
-		if err != nil {
-			return device
-		}
-		return attachedDeviceName
-	} 
-	return ""
-	
-}

--- a/libstorage/drivers/storage/cinder/storage/cinder_storage.go
+++ b/libstorage/drivers/storage/cinder/storage/cinder_storage.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+	"strings"
 
 	gofig "github.com/akutz/gofig/types"
 	"github.com/akutz/goof"
@@ -327,10 +328,14 @@ func translateVolume(
 	var attachments []*types.VolumeAttachment
 	if includeAttachments.Requested() {
 		for _, attachment := range volume.Attachments {
+			deviceName:= strings.Replace(
+				string(attachment.Device),
+				"/dev/sd",
+				"/dev/xvd", 1)
 			libstorageAttachment := &types.VolumeAttachment{
 				VolumeID:   attachment.VolumeID,
 				InstanceID: &types.InstanceID{ID: attachment.ServerID, Driver: cinder.Name},
-				DeviceName: attachment.Device,
+				DeviceName: deviceName,
 				Status:     "",
 			}
 			attachments = append(attachments, libstorageAttachment)
@@ -894,3 +899,5 @@ func (d *driver) caCert() string {
 func (d *driver) insecure() bool {
 	return d.config.GetBool(cinder.ConfigInsecure)
 }
+
+

--- a/libstorage/drivers/storage/cinder/storage/cinder_storage.go
+++ b/libstorage/drivers/storage/cinder/storage/cinder_storage.go
@@ -7,6 +7,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+	"strings"
+	"fmt"
+	"path/filepath"
 
 	gofig "github.com/akutz/gofig/types"
 	"github.com/akutz/goof"
@@ -907,3 +910,21 @@ func (d *driver) insecure() bool {
 }
 
 
+func (d *driver) ResolveDeviceName(ctx types.Context, device string, volumeID string) string{
+	if strings.ToLower(d.config.GetString(cinder.ConfigMappingType))=="ebs" {
+	return strings.Replace(
+		string(device),
+		d.config.GetString(cinder.ConfigDevicePattern),
+		d.config.GetString(cinder.ConfigHostPattern),
+		1)
+	} else if strings.ToLower(d.config.GetString(cinder.ConfigMappingType))=="virtio"{
+		attachedDeviceLink := fmt.Sprintf("/dev/disk/by-id/virtio-%s", volumeID[:20])
+	    attachedDeviceName, err := filepath.EvalSymlinks(attachedDeviceLink)
+		if err != nil {
+			return device
+		}
+		return attachedDeviceName
+	} 
+	return ""
+	
+}

--- a/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -279,14 +279,8 @@ func (c *client) WaitForDevice(
 				if err != nil {
 					return false, nil, err
 				}
-				for k,v := range ld.DeviceMap {
-					// change the name of the device maped by the system to match the one that Cinder use
-					// usually the device /dev/xvdb will be reported as /dev/sdb
-					// if strings.Replace(strings.ToLower(k),"/dev/xvd","/dev/sd",1) == opts.Token {
-					// 	return true, ld, nil
-					// }
-					if strings.ToLower(k) == opts.Token ||
-					   strings.ToLower(v) == opts.Token {
+				for k := range ld.DeviceMap {
+					if strings.ToLower(k) == opts.Token {
 						return true, ld, nil
 					}
 				}

--- a/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -279,10 +279,14 @@ func (c *client) WaitForDevice(
 				if err != nil {
 					return false, nil, err
 				}
-				for k := range ld.DeviceMap {
+				for k,v := range ld.DeviceMap {
 					// change the name of the device maped by the system to match the one that Cinder use
 					// usually the device /dev/xvdb will be reported as /dev/sdb
-					if strings.Replace(strings.ToLower(k),"/dev/xvd","/dev/sd",1) == opts.Token {
+					// if strings.Replace(strings.ToLower(k),"/dev/xvd","/dev/sd",1) == opts.Token {
+					// 	return true, ld, nil
+					// }
+					if strings.ToLower(k) == opts.Token ||
+					   strings.ToLower(v) == opts.Token {
 						return true, ld, nil
 					}
 				}

--- a/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/libstorage/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -280,7 +280,9 @@ func (c *client) WaitForDevice(
 					return false, nil, err
 				}
 				for k := range ld.DeviceMap {
-					if strings.ToLower(k) == opts.Token {
+					// change the name of the device maped by the system to match the one that Cinder use
+					// usually the device /dev/xvdb will be reported as /dev/sdb
+					if strings.Replace(strings.ToLower(k),"/dev/xvd","/dev/sd",1) == opts.Token {
 						return true, ld, nil
 					}
 				}


### PR DESCRIPTION
This pull request fixed an issue I encountered on the Flexible Engine Cloud provided by Orange (based on Huawei cloud solution). On this cloud when using Xen hypervisors the volumes would be mounted like  the EBS volumes: mapping is done with the /dev/xdv[b-z] pattern instead of the /dev/sd[b-z] pattern reported by cinder. 
When using KVM hypervisors (virtio) I have taken the change proposed by the nokia fork to retrieve the mount point using the device id.
The behavior of the device resolution name can be controlled with the mappingType parameter which can take the following values:
 - « ebs »: will act like the ebs plugin replacing the pattern /dev/sd with /dev/xdv. The pattern can be change with the two parameters deviceMapping and hostMapping
 - « virtio »: will resolve the device name based of the volume id in /dev/disk/by-id
 - «  »: default value, will fall back to the current plugin behavior. 