### PR TITLE
Show warning message when the tar.gz/deb/rpm file is not found

### DIFF
--- a/install
+++ b/install
@@ -167,7 +167,12 @@ install() {
         sudo mkdir -p $BIN_DIR
         if [ "$?" -ne "0" ]; then exit $?; fi
 
-        curl $INSECURE -o $FILE_NAME -sSL $URL
+        status=$(curl $INSECURE -o $FILE_NAME -fsSL $URL 2> /dev/null)
+        if [ "$?" -eq "22" ]; then 
+            echo "Unable to download the package. Please make sure your platform is supported."
+            exit $status; 
+		fi
+		
         if [ "$?" -ne "0" ]; then exit $?; fi
 
         sudo tar xzf $FILE_NAME -C $BIN_DIR


### PR DESCRIPTION
Hi, I am using macOS and I tried to install rexray. And it shows "tar: Unrecognized archive format".
It was quite confusing and I had to do some research to find out what happened.
It was not until then that I realized macOS is not supported. 
So this commit will make the script show the warning message "Unable to download the package. Please make sure your platform is supported." when curl can't download the tarball. I think it may make the error message a little bit more friendly.