### PR TITLE
Fixed 404 when checking for DO action too fast

### DIFF
--- a/libstorage/drivers/storage/dobs/storage/dobs_storage.go
+++ b/libstorage/drivers/storage/dobs/storage/dobs_storage.go
@@ -511,17 +511,22 @@ func (d *driver) waitForAction(
 	f := func() (interface{}, error) {
 		duration := d.statusDelay
 		for i := 1; i <= d.maxAttempts; i++ {
-			action, _, err := d.client.StorageActions.Get(
+	        var response *godo.Response
+			action, response, err := d.client.StorageActions.Get(
 				ctx, volumeID, action.ID)
-			if err != nil {
+
+			if response != nil && response.StatusCode == 404{
+				ctx.Debug("DigitalOcean not ready yet, sleeping")
+			}else if err != nil {
 				return nil, err
+			}else if action != nil{
+				if action.Status == godo.ActionCompleted {
+					return nil, nil
+				}
+				ctx.WithField("status", action.Status).Debug(
+					"still waiting for action",
+				)
 			}
-			if action.Status == godo.ActionCompleted {
-				return nil, nil
-			}
-			ctx.WithField("status", action.Status).Debug(
-				"still waiting for action",
-			)
 			time.Sleep(time.Duration(duration) * time.Nanosecond)
 			duration = int64(2) * duration
 		}


### PR DESCRIPTION
The Digital Ocean API isn't fast enough (consistently in my case). When attaching a volume the library checks for the action in the API too fast so DO returns a 404.

This fix assumes that the 404 is similar to other not-ready errors.

Example command that used to fail consistently for me:
```
rexray volume attach <volume>
```

Example log errors before:
```
time="2020-04-30T13:34:40Z" level=error msg="Error while waiting for storage action to finish" host="unix:///var/run/rexray.sock" inner="GET https://api.digitalocean.com/v2/volumes/<volume>/actions/<droplet>: 404 (request \"...\") could not get volume action: no volume event found" instanceID="dobs=...,name=docker-00&region=ams3" route=volumeAttach server=boom-scribe-cm service=dobs storageDriver=dobs task=0 time=1588253680334 tls=false txCR=... txID=... volumeID=...
time="2020-04-30T13:34:40Z" level=error msg="error: api call failed" error.volumeID=... host="unix:///var/run/rexray.sock" route=volumeAttach server=boom-scribe-cm time=1588253680334 tls=false txCR=... txID=...
```